### PR TITLE
fix: Correct syntax and version number for unicodecsv

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ matplotlib==3.7.1
 chardet==5.1.0
 openpyxl==3.0.9
 pyyaml==6.0
-unicodecsv=1.3.7
+unicodecsv==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ chardet==5.1.0
 openpyxl==3.0.9
 pyyaml==6.0
 unicodecsv==0.14.1
+Unidecode==1.3.7


### PR DESCRIPTION
Fixes the following errors :
❯ pip install -r requirements.txt
ERROR: Invalid requirement: 'unicodecsv=1.3.7' (from line 8 of requirements.txt) Hint: = is not a valid operator. Did you mean == ?

ERROR: Could not find a version that satisfies the requirement unicodecsv==1.3.7 (from versions: 0.8.0, 0.9.0, 0.9.3, 0.9.4, 0.11.0, 0.11.1, 0.11.2, 0.12.0, 0.13.0, 0.14.0, 0.14.1)
ERROR: No matching distribution found for unicodecsv==1.3.7